### PR TITLE
Redesign all demos: clean, human-centered UI

### DIFF
--- a/src/app/demos/example-text-to-image/page.tsx
+++ b/src/app/demos/example-text-to-image/page.tsx
@@ -31,46 +31,33 @@ export default function ExampleTextToImage() {
   }
 
   return (
-    <div className="min-h-screen bg-[#0a0015] text-white relative overflow-hidden">
-      {/* Ambient gradients */}
-      <div className="fixed inset-0 pointer-events-none">
-        <div className="absolute -top-40 -left-40 w-[500px] h-[500px] bg-purple-600/15 rounded-full blur-[120px]" />
-        <div className="absolute -bottom-40 -right-40 w-[500px] h-[500px] bg-fuchsia-600/15 rounded-full blur-[120px]" />
-        <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[600px] bg-violet-600/8 rounded-full blur-[150px]" />
-      </div>
-
-      <div className="relative z-10 max-w-3xl mx-auto px-6 py-16">
+    <div className="min-h-screen bg-[#FAFAF8] text-[#1A1A1A]">
+      <div className="max-w-2xl mx-auto px-6 py-16">
         {/* Header */}
         <div className="text-center mb-12">
-          <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-purple-500/10 border border-purple-500/20 text-purple-300 text-xs font-medium mb-4">
-            <span className="w-1.5 h-1.5 rounded-full bg-purple-400 animate-pulse" />
-            Powered by MiniMax
-          </div>
-          <h1 className="text-5xl font-bold tracking-tight mb-3">
-            <span className="bg-gradient-to-r from-purple-300 via-fuchsia-300 to-pink-300 bg-clip-text text-transparent">
-              Imagine Anything
-            </span>
+          <h1 className="text-4xl font-semibold tracking-tight text-[#1A1A1A]">
+            Text to Image
           </h1>
-          <p className="text-gray-400 text-lg">
-            Describe a scene and bring it to life with AI
+          <p className="text-[#6B6B6B] text-base mt-2">
+            Describe what you want to see
           </p>
         </div>
 
         {/* Input */}
-        <div className="rounded-2xl border border-purple-500/20 bg-white/[0.03] backdrop-blur-sm p-1.5 mb-8">
+        <div className="rounded-xl border border-[#E8E8E6] bg-white p-1.5 mb-8 shadow-sm">
           <div className="flex gap-2">
             <input
               type="text"
               value={prompt}
               onChange={(e) => setPrompt(e.target.value)}
               onKeyDown={(e) => e.key === "Enter" && handleGenerate()}
-              placeholder="A futuristic city floating in the clouds at golden hour..."
-              className="flex-1 bg-transparent px-5 py-3.5 text-white placeholder-gray-500 focus:outline-none text-sm"
+              placeholder="A golden retriever sitting in a field of wildflowers..."
+              className="flex-1 bg-transparent px-5 py-3.5 text-[#1A1A1A] placeholder-[#9CA3A0] focus:outline-none text-sm"
             />
             <button
               onClick={handleGenerate}
               disabled={loading || !prompt.trim()}
-              className="rounded-xl bg-gradient-to-r from-purple-600 to-fuchsia-600 px-6 py-3.5 font-semibold text-sm shadow-lg shadow-purple-500/20 hover:shadow-purple-500/40 hover:from-purple-500 hover:to-fuchsia-500 disabled:opacity-40 disabled:cursor-not-allowed disabled:shadow-none transition-all"
+              className="rounded-lg bg-[#1A1A1A] text-white px-6 py-3.5 font-medium text-sm hover:bg-[#333333] disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
             >
               {loading ? (
                 <span className="flex items-center gap-2">
@@ -89,32 +76,32 @@ export default function ExampleTextToImage() {
 
         {/* Error */}
         {error && (
-          <div className="mb-6 rounded-xl bg-red-500/10 border border-red-500/20 p-4 text-red-300 text-sm">
+          <div className="mb-6 rounded-lg bg-red-50 border border-red-200 p-4 text-red-700 text-sm">
             {error}
           </div>
         )}
 
         {/* Result */}
         {imageUrl && (
-          <div className="rounded-2xl overflow-hidden border border-purple-500/20 shadow-2xl shadow-purple-500/10">
+          <div className="rounded-xl overflow-hidden border border-[#E8E8E6] shadow-lg">
             <img
               src={imageUrl}
               alt={prompt}
               className="w-full"
             />
-            <div className="bg-white/[0.03] backdrop-blur-sm px-5 py-3 border-t border-purple-500/10">
-              <p className="text-xs text-gray-500 truncate">{prompt}</p>
+            <div className="bg-[#F5F5F3] px-5 py-3 border-t border-[#E8E8E6]">
+              <p className="text-xs text-[#6B6B6B] truncate">{prompt}</p>
             </div>
           </div>
         )}
 
         {/* Empty state */}
         {!imageUrl && !loading && !error && (
-          <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-purple-500/20 py-24 text-gray-600">
-            <svg className="w-12 h-12 mb-3 text-purple-500/30" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-[#D4D4D2] py-24">
+            <svg className="w-12 h-12 mb-3 text-[#C4C4C2]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M2.25 15.75l5.159-5.159a2.25 2.25 0 013.182 0l5.159 5.159m-1.5-1.5l1.409-1.409a2.25 2.25 0 013.182 0l2.909 2.909M3.75 21h16.5A2.25 2.25 0 0022.5 18.75V5.25A2.25 2.25 0 0020.25 3H3.75A2.25 2.25 0 001.5 5.25v13.5A2.25 2.25 0 003.75 21z" />
             </svg>
-            <p className="text-sm">Your creation will appear here</p>
+            <p className="text-sm text-[#9CA3A0]">Your image will appear here</p>
           </div>
         )}
       </div>

--- a/src/app/demos/memory-stream/page.tsx
+++ b/src/app/demos/memory-stream/page.tsx
@@ -51,7 +51,7 @@ Grew up in Portland, Oregon. Passionate about AI safety, hiking, and film photog
 function ShimmerBlock({ className }: { className?: string }) {
   return (
     <div
-      className={`animate-pulse rounded-xl bg-gradient-to-r from-gray-800 via-gray-700 to-gray-800 bg-[length:200%_100%] ${className ?? ""}`}
+      className={`animate-pulse rounded-lg bg-gradient-to-r from-[#E7E5E0] via-[#F0EFEC] to-[#E7E5E0] bg-[length:200%_100%] ${className ?? ""}`}
       style={{
         animation: "shimmer 2s ease-in-out infinite",
       }}
@@ -82,12 +82,12 @@ function PhaseCard({
     >
       {/* Timeline dot */}
       <div className="absolute left-1/2 -translate-x-1/2 hidden md:flex flex-col items-center z-10">
-        <div className="w-4 h-4 rounded-full bg-indigo-500 border-4 border-gray-950 shadow-lg shadow-indigo-500/30" />
+        <div className="w-3 h-3 rounded-full bg-[#C67D4B] border-4 border-[#FAF9F6]" />
       </div>
 
       {/* Image side */}
       <div className={`w-full md:w-[calc(50%-2.5rem)] ${isLeft ? "md:text-right" : "md:text-left"}`}>
-        <div className="relative aspect-[16/10] rounded-xl overflow-hidden border border-gray-800/50 shadow-2xl">
+        <div className="relative aspect-[16/10] rounded-lg overflow-hidden border border-[#E7E5E0] shadow-md">
           {phase.imageLoading ? (
             <ShimmerBlock className="absolute inset-0" />
           ) : phase.imageUrl ? (
@@ -97,28 +97,28 @@ function PhaseCard({
               className="absolute inset-0 w-full h-full object-cover"
             />
           ) : (
-            <div className="absolute inset-0 flex items-center justify-center bg-gray-900 text-gray-600 text-sm">
+            <div className="absolute inset-0 flex items-center justify-center bg-[#F0EFEC] text-[#A8A29E] text-sm">
               {phase.imageError ?? "Image unavailable"}
             </div>
           )}
           {/* Gradient overlay */}
-          <div className="absolute inset-0 bg-gradient-to-t from-gray-950/60 to-transparent" />
+          <div className="absolute inset-0 bg-gradient-to-t from-black/20 to-transparent" />
         </div>
       </div>
 
       {/* Text side */}
       <div className={`w-full md:w-[calc(50%-2.5rem)] ${isLeft ? "" : ""}`}>
         {/* Year badge */}
-        <span className="inline-block px-3 py-1 rounded-full text-xs font-mono font-semibold bg-indigo-500/20 text-indigo-300 border border-indigo-500/30 mb-3">
+        <span className="inline-block px-3 py-1 rounded-full text-xs font-mono font-medium bg-[#FDF3EC] text-[#9A5C30] border border-[#E7D5C4] mb-3">
           {phase.yearRange}
         </span>
-        <h3 className="text-xl md:text-2xl font-bold text-gray-100 mb-2 leading-tight">
+        <h3 className="text-xl md:text-2xl font-serif font-semibold text-[#2C2420] mb-2 leading-tight">
           {phase.title}
         </h3>
-        <p className="text-gray-400 leading-relaxed text-sm md:text-base">
+        <p className="text-[#7A746E] leading-relaxed text-sm md:text-base">
           {phase.description}
         </p>
-        <p className="mt-2 text-xs text-gray-600 italic">
+        <p className="mt-2 text-xs text-[#A8A29E] italic">
           {phase.audioMood}
         </p>
       </div>
@@ -298,7 +298,7 @@ export default function MemoryStreamPage() {
   const showTimeline = phases.length > 0;
 
   return (
-    <div className="min-h-screen bg-gray-950 text-gray-100">
+    <div className="min-h-screen bg-[#FAF9F6] text-[#2C2420]">
       {/* Shimmer keyframes */}
       <style>{`
         @keyframes shimmer {
@@ -307,33 +307,25 @@ export default function MemoryStreamPage() {
         }
       `}</style>
 
-      {/* Ambient background glow */}
-      <div className="fixed inset-0 pointer-events-none">
-        <div className="absolute top-0 left-1/4 w-96 h-96 bg-indigo-900/10 rounded-full blur-3xl" />
-        <div className="absolute bottom-0 right-1/4 w-96 h-96 bg-purple-900/10 rounded-full blur-3xl" />
-      </div>
-
-      <div className="relative z-10 max-w-5xl mx-auto px-4 py-8 md:py-12">
+      <div className="max-w-5xl mx-auto px-4 py-8 md:py-12">
         {/* Header */}
         <div className="text-center mb-10">
-          <h1 className="text-4xl md:text-5xl font-bold tracking-tight mb-3">
-            <span className="bg-gradient-to-r from-indigo-400 via-purple-400 to-pink-400 bg-clip-text text-transparent">
-              Memory Stream
-            </span>
+          <h1 className="text-4xl md:text-5xl font-serif font-semibold tracking-tight text-[#2C2420] mb-3">
+            Memory Stream
           </h1>
-          <p className="text-gray-400 max-w-xl mx-auto text-lg">
-            Paste your LinkedIn profile and watch your life story unfold as a
-            cinematic memory stream — with AI-generated visuals.
+          <p className="text-[#7A746E] max-w-xl mx-auto text-lg leading-relaxed">
+            Paste your LinkedIn profile and see your career journey told as a
+            visual story.
           </p>
         </div>
 
         {/* Input section */}
         {!showTimeline && (
           <div className="max-w-2xl mx-auto">
-            <div className="rounded-2xl border border-gray-800/50 bg-gray-900/50 backdrop-blur-sm p-6 shadow-xl">
+            <div className="rounded-xl border border-[#E7E5E0] bg-white p-6 shadow-sm">
               <label
                 htmlFor="profile-input"
-                className="block text-sm font-medium text-gray-300 mb-2"
+                className="block text-sm font-medium text-[#2C2420] mb-2"
               >
                 LinkedIn Profile Text
               </label>
@@ -343,14 +335,14 @@ export default function MemoryStreamPage() {
                 onChange={(e) => setProfileText(e.target.value)}
                 placeholder={`Paste your LinkedIn profile here...\n\nInclude your name, education, work history, locations, and any other details you'd like to see in your memory stream.`}
                 rows={10}
-                className="w-full rounded-xl border border-gray-700/50 bg-gray-800/50 px-4 py-3 text-gray-100 placeholder-gray-600 focus:border-indigo-500/50 focus:outline-none focus:ring-1 focus:ring-indigo-500/25 resize-none text-sm leading-relaxed"
+                className="w-full rounded-lg border border-[#E7E5E0] bg-[#FAF9F6] px-4 py-3 text-[#2C2420] placeholder-[#A8A29E] focus:border-[#C67D4B] focus:outline-none focus:ring-1 focus:ring-[#C67D4B]/25 resize-none text-sm leading-relaxed"
               />
 
               <div className="flex flex-col sm:flex-row gap-3 mt-4">
                 <button
                   onClick={handleGenerate}
                   disabled={generating || !profileText.trim()}
-                  className="flex-1 rounded-xl bg-gradient-to-r from-indigo-600 to-purple-600 px-6 py-3 font-semibold text-white shadow-lg shadow-indigo-500/20 hover:from-indigo-500 hover:to-purple-500 disabled:opacity-40 disabled:cursor-not-allowed transition-all duration-200"
+                  className="flex-1 rounded-lg bg-[#3D3229] px-6 py-3 font-medium text-white hover:bg-[#524639] disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
                 >
                   {generating ? (
                     <span className="flex items-center justify-center gap-2">
@@ -373,23 +365,23 @@ export default function MemoryStreamPage() {
                           d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
                         />
                       </svg>
-                      Reconstructing Memories...
+                      Building timeline...
                     </span>
                   ) : (
-                    "Generate Memory Stream"
+                    "Create Timeline"
                   )}
                 </button>
                 <button
                   onClick={handleTryDemo}
                   disabled={generating}
-                  className="rounded-xl border border-gray-700 px-6 py-3 text-sm text-gray-400 hover:text-gray-200 hover:border-gray-600 disabled:opacity-40 disabled:cursor-not-allowed transition-all duration-200"
+                  className="rounded-lg border border-[#E7E5E0] px-6 py-3 text-sm text-[#7A746E] hover:text-[#2C2420] hover:border-[#C67D4B] disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
                 >
                   Try Demo Profile
                 </button>
               </div>
             </div>
 
-            <p className="text-center text-xs text-gray-600 mt-4">
+            <p className="text-center text-xs text-[#A8A29E] mt-4">
               Your profile text is processed by AI to create a fictional
               narrative. No data is stored.
             </p>
@@ -401,12 +393,12 @@ export default function MemoryStreamPage() {
 
         {/* Error state */}
         {error && (
-          <div className="max-w-2xl mx-auto mt-6 rounded-xl bg-red-900/20 border border-red-800/50 p-4 text-red-300 text-sm">
+          <div className="max-w-2xl mx-auto mt-6 rounded-lg bg-[#FEF2F2] border border-red-200 p-4 text-red-700 text-sm">
             <p className="font-medium mb-1">Generation failed</p>
-            <p className="text-red-400">{error}</p>
+            <p className="text-red-700">{error}</p>
             <button
               onClick={() => setError(null)}
-              className="mt-2 text-xs text-red-500 hover:text-red-300 underline"
+              className="mt-2 text-xs text-red-700 hover:text-red-900 underline"
             >
               Dismiss
             </button>
@@ -419,10 +411,10 @@ export default function MemoryStreamPage() {
             {/* Person name header */}
             {personName && (
               <div className="text-center mb-12 animate-fade-in">
-                <p className="text-sm text-indigo-400 uppercase tracking-widest mb-2">
+                <p className="text-sm text-[#9A5C30] uppercase tracking-widest mb-2 font-medium">
                   The Memory Stream of
                 </p>
-                <h2 className="text-3xl md:text-4xl font-bold text-gray-100">
+                <h2 className="text-3xl md:text-4xl font-serif font-semibold text-[#2C2420]">
                   {personName}
                 </h2>
               </div>
@@ -436,7 +428,7 @@ export default function MemoryStreamPage() {
                   setPersonName(null);
                   setVisiblePhases(new Set());
                 }}
-                className="text-sm text-gray-500 hover:text-gray-300 underline transition-colors"
+                className="text-sm text-[#A8A29E] hover:text-[#2C2420] underline transition-colors"
               >
                 Start over with a new profile
               </button>
@@ -444,7 +436,7 @@ export default function MemoryStreamPage() {
 
             {/* Vertical timeline line (desktop only) */}
             <div className="relative">
-              <div className="hidden md:block absolute left-1/2 -translate-x-px top-0 bottom-0 w-0.5 bg-gradient-to-b from-indigo-500/50 via-purple-500/30 to-transparent" />
+              <div className="hidden md:block absolute left-1/2 -translate-x-px top-0 bottom-0 w-px bg-[#D6D0C8]" />
 
               {/* Phase cards */}
               <div className="space-y-16 md:space-y-24">
@@ -462,8 +454,8 @@ export default function MemoryStreamPage() {
               {!generating && (
                 <div className="flex justify-center mt-16">
                   <div className="text-center">
-                    <div className="w-3 h-3 rounded-full bg-purple-500/50 mx-auto mb-3" />
-                    <p className="text-sm text-gray-500 italic">
+                    <div className="w-2 h-2 rounded-full bg-[#D6D0C8] mx-auto mb-3" />
+                    <p className="text-sm text-[#A8A29E] italic">
                       The stream continues...
                     </p>
                   </div>

--- a/src/app/demos/nutrition-assistant/page.tsx
+++ b/src/app/demos/nutrition-assistant/page.tsx
@@ -70,10 +70,10 @@ function compressImage(file: File, maxSize = 1024, quality = 0.8): Promise<strin
 
 // ─── Health goal options ─────────────────────────────────────────────────────
 
-const HEALTH_GOALS: { value: HealthGoal; label: string; icon: string }[] = [
-  { value: "weight-loss", label: "Weight Loss", icon: "🔥" },
-  { value: "muscle-gain", label: "Muscle Gain", icon: "💪" },
-  { value: "maintenance", label: "Maintenance", icon: "⚖️" },
+const HEALTH_GOALS: { value: HealthGoal; label: string }[] = [
+  { value: "weight-loss", label: "Weight Loss" },
+  { value: "muscle-gain", label: "Muscle Gain" },
+  { value: "maintenance", label: "Maintenance" },
 ];
 
 // ─── Component ───────────────────────────────────────────────────────────────
@@ -201,27 +201,15 @@ export default function NutritionAssistantPage() {
     : 0;
 
   return (
-    <div className="min-h-screen bg-[#0a1a0f] text-gray-100 relative overflow-hidden">
-      {/* Ambient glow */}
-      <div className="fixed inset-0 pointer-events-none">
-        <div className="absolute -top-40 left-1/2 -translate-x-1/2 w-[600px] h-[400px] bg-emerald-600/10 rounded-full blur-[120px]" />
-        <div className="absolute -bottom-40 right-0 w-[400px] h-[400px] bg-teal-600/8 rounded-full blur-[100px]" />
-      </div>
-
-      <div className="relative z-10 max-w-lg mx-auto px-4 py-12 pb-12">
+    <div className="min-h-screen bg-[#F7F8FA] text-[#1C1E21]">
+      <div className="max-w-lg mx-auto px-4 py-12">
         {/* Header */}
         <div className="text-center mb-8">
-          <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-emerald-500/10 border border-emerald-500/20 text-emerald-300 text-xs font-medium mb-4">
-            <span className="w-1.5 h-1.5 rounded-full bg-emerald-400 animate-pulse" />
-            Powered by MiniMax
-          </div>
-          <h1 className="text-3xl font-bold text-white mb-2">
-            <span className="bg-gradient-to-r from-emerald-300 via-teal-300 to-cyan-300 bg-clip-text text-transparent">
-              Nutrition Assistant
-            </span>
+          <h1 className="text-2xl font-semibold text-[#1C1E21] mb-1">
+            Nutrition Assistant
           </h1>
-          <p className="text-gray-400 text-sm">
-            Snap a photo of your food for instant calorie and nutrition analysis
+          <p className="text-gray-500 text-sm">
+            Upload a photo of your meal to get nutritional info
           </p>
         </div>
 
@@ -230,22 +218,22 @@ export default function NutritionAssistantPage() {
           <button
             type="button"
             onClick={() => fileInputRef.current?.click()}
-            className="w-full aspect-[4/3] rounded-2xl border-2 border-dashed border-gray-700 hover:border-green-500/50 bg-gray-900/50 hover:bg-gray-900 transition-all flex flex-col items-center justify-center gap-3 cursor-pointer mb-6"
+            className="w-full aspect-[4/3] rounded-xl border-2 border-dashed border-gray-300 hover:border-[#34A853] bg-white hover:bg-[#F0FAF0] transition-all flex flex-col items-center justify-center gap-3 cursor-pointer mb-6"
           >
-            <div className="w-14 h-14 rounded-full bg-green-500/10 flex items-center justify-center">
-              <svg className="w-7 h-7 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <div className="w-14 h-14 rounded-full bg-[#F0FAF0] flex items-center justify-center">
+              <svg className="w-7 h-7 text-[#34A853]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M6.827 6.175A2.31 2.31 0 015.186 7.23c-.38.054-.757.112-1.134.175C2.999 7.58 2.25 8.507 2.25 9.574V18a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9.574c0-1.067-.75-1.994-1.802-2.169a47.865 47.865 0 00-1.134-.175 2.31 2.31 0 01-1.64-1.055l-.822-1.316a2.192 2.192 0 00-1.736-1.039 48.774 48.774 0 00-5.232 0 2.192 2.192 0 00-1.736 1.039l-.821 1.316z" />
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M16.5 12.75a4.5 4.5 0 11-9 0 4.5 4.5 0 019 0z" />
               </svg>
             </div>
             <div className="text-center">
-              <p className="text-sm font-medium text-gray-300">Take a photo or upload an image</p>
-              <p className="text-xs text-gray-500 mt-1">Tap to open camera or choose file</p>
+              <p className="text-sm font-medium text-[#1C1E21]">Take a photo or upload an image</p>
+              <p className="text-xs text-gray-400 mt-1">Tap to open camera or choose file</p>
             </div>
           </button>
         ) : (
           <div className="relative mb-6">
-            <div className="rounded-2xl overflow-hidden border border-gray-800">
+            <div className="rounded-xl overflow-hidden border border-gray-200">
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
                 src={imagePreview}
@@ -256,7 +244,7 @@ export default function NutritionAssistantPage() {
             <button
               type="button"
               onClick={handleReset}
-              className="absolute top-3 right-3 w-8 h-8 rounded-full bg-gray-900/80 backdrop-blur flex items-center justify-center text-gray-400 hover:text-white transition-colors"
+              className="absolute top-3 right-3 w-8 h-8 rounded-full bg-white/90 shadow-sm flex items-center justify-center text-gray-500 hover:text-[#1C1E21] transition-colors"
             >
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -277,7 +265,7 @@ export default function NutritionAssistantPage() {
 
         {/* Health goal selector */}
         <div className="mb-6">
-          <label className="block text-sm font-medium text-gray-400 mb-3">
+          <label className="block text-sm font-medium text-gray-600 mb-3">
             Your Health Goal
           </label>
           <div className="flex gap-2">
@@ -288,11 +276,10 @@ export default function NutritionAssistantPage() {
                 onClick={() => setHealthGoal(goal.value)}
                 className={`flex-1 py-2.5 px-3 rounded-xl text-sm font-medium transition-all ${
                   healthGoal === goal.value
-                    ? "bg-green-500/20 text-green-400 border border-green-500/40"
-                    : "bg-gray-900 text-gray-400 border border-gray-800 hover:border-gray-700"
+                    ? "bg-[#F0FAF0] text-[#34A853] border border-[#34A853]"
+                    : "bg-white text-gray-600 border border-gray-200 hover:border-gray-400"
                 }`}
               >
-                <span className="block text-lg mb-0.5">{goal.icon}</span>
                 {goal.label}
               </button>
             ))}
@@ -304,7 +291,7 @@ export default function NutritionAssistantPage() {
           type="button"
           onClick={handleAnalyze}
           disabled={!imageBase64 || loading}
-          className="w-full py-3.5 rounded-xl font-semibold text-sm transition-all disabled:opacity-40 disabled:cursor-not-allowed bg-green-500 hover:bg-green-400 text-gray-950 mb-6"
+          className="w-full py-3.5 rounded-lg font-medium text-sm transition-colors disabled:opacity-40 disabled:cursor-not-allowed bg-[#34A853] hover:bg-[#2D9249] text-white mb-6"
         >
           {loading ? (
             <span className="inline-flex items-center gap-2">
@@ -321,7 +308,7 @@ export default function NutritionAssistantPage() {
 
         {/* Error message */}
         {error && (
-          <div className="mb-6 p-4 rounded-xl bg-red-500/10 border border-red-500/20 text-red-400 text-sm">
+          <div className="mb-6 p-4 rounded-lg bg-[#FEF2F2] border border-red-200 text-red-700 text-sm">
             {error}
           </div>
         )}
@@ -329,9 +316,9 @@ export default function NutritionAssistantPage() {
         {/* Loading skeleton */}
         {loading && (
           <div className="space-y-4 animate-pulse">
-            <div className="h-24 rounded-xl bg-gray-900" />
-            <div className="h-32 rounded-xl bg-gray-900" />
-            <div className="h-20 rounded-xl bg-gray-900" />
+            <div className="h-24 rounded-lg bg-gray-100" />
+            <div className="h-32 rounded-lg bg-gray-100" />
+            <div className="h-20 rounded-lg bg-gray-100" />
           </div>
         )}
 
@@ -339,53 +326,53 @@ export default function NutritionAssistantPage() {
         {result && !loading && (
           <div className="space-y-4">
             {/* Foods detected */}
-            <div className="rounded-xl bg-gray-900 border border-gray-800 p-4">
-              <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-3">
+            <div className="rounded-lg bg-white border border-gray-200 p-4 shadow-sm">
+              <h2 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">
                 Foods Detected
               </h2>
               <ul className="space-y-2">
                 {result.foods.map((food, i) => (
                   <li key={i} className="flex items-center justify-between">
                     <div className="flex items-center gap-2">
-                      <span className="w-2 h-2 rounded-full bg-green-400" />
-                      <span className="text-sm text-gray-200">{food.name}</span>
+                      <span className="w-2 h-2 rounded-full bg-[#34A853]" />
+                      <span className="text-sm text-[#1C1E21]">{food.name}</span>
                       <span className="text-xs text-gray-500">
                         {Math.round(food.confidence * 100)}%
                       </span>
                     </div>
-                    <span className="text-sm font-medium text-gray-300">
+                    <span className="text-sm font-medium text-[#1C1E21]">
                       {food.calories} cal
                     </span>
                   </li>
                 ))}
               </ul>
-              <div className="mt-3 pt-3 border-t border-gray-800 flex justify-between">
-                <span className="text-sm font-semibold text-white">Total</span>
-                <span className="text-sm font-bold text-green-400">
+              <div className="mt-3 pt-3 border-t border-gray-200 flex justify-between">
+                <span className="text-sm font-semibold text-[#1C1E21]">Total</span>
+                <span className="text-sm font-semibold text-[#34A853]">
                   {result.totalCalories} cal
                 </span>
               </div>
             </div>
 
             {/* Macro breakdown */}
-            <div className="rounded-xl bg-gray-900 border border-gray-800 p-4">
-              <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-3">
+            <div className="rounded-lg bg-white border border-gray-200 p-4 shadow-sm">
+              <h2 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">
                 Macro Breakdown
               </h2>
               <div className="space-y-3">
                 {/* Protein */}
                 <div>
                   <div className="flex justify-between text-xs mb-1">
-                    <span className="text-blue-400 font-medium">Protein</span>
-                    <span className="text-gray-400">
+                    <span className="text-[#5B8DEF] font-medium">Protein</span>
+                    <span className="text-gray-500">
                       {result.macros.protein}g
                       {totalMacroGrams > 0 &&
                         ` (${Math.round((result.macros.protein / totalMacroGrams) * 100)}%)`}
                     </span>
                   </div>
-                  <div className="h-2.5 rounded-full bg-gray-800 overflow-hidden">
+                  <div className="h-2.5 rounded-full bg-gray-100 overflow-hidden">
                     <div
-                      className="h-full rounded-full bg-blue-500 transition-all duration-700"
+                      className="h-full rounded-full bg-[#5B8DEF] transition-all duration-700"
                       style={{
                         width: totalMacroGrams > 0
                           ? `${(result.macros.protein / totalMacroGrams) * 100}%`
@@ -397,16 +384,16 @@ export default function NutritionAssistantPage() {
                 {/* Carbs */}
                 <div>
                   <div className="flex justify-between text-xs mb-1">
-                    <span className="text-yellow-400 font-medium">Carbs</span>
-                    <span className="text-gray-400">
+                    <span className="text-[#F2A735] font-medium">Carbs</span>
+                    <span className="text-gray-500">
                       {result.macros.carbs}g
                       {totalMacroGrams > 0 &&
                         ` (${Math.round((result.macros.carbs / totalMacroGrams) * 100)}%)`}
                     </span>
                   </div>
-                  <div className="h-2.5 rounded-full bg-gray-800 overflow-hidden">
+                  <div className="h-2.5 rounded-full bg-gray-100 overflow-hidden">
                     <div
-                      className="h-full rounded-full bg-yellow-500 transition-all duration-700"
+                      className="h-full rounded-full bg-[#F2A735] transition-all duration-700"
                       style={{
                         width: totalMacroGrams > 0
                           ? `${(result.macros.carbs / totalMacroGrams) * 100}%`
@@ -418,16 +405,16 @@ export default function NutritionAssistantPage() {
                 {/* Fat */}
                 <div>
                   <div className="flex justify-between text-xs mb-1">
-                    <span className="text-red-400 font-medium">Fat</span>
-                    <span className="text-gray-400">
+                    <span className="text-[#EF7B6C] font-medium">Fat</span>
+                    <span className="text-gray-500">
                       {result.macros.fat}g
                       {totalMacroGrams > 0 &&
                         ` (${Math.round((result.macros.fat / totalMacroGrams) * 100)}%)`}
                     </span>
                   </div>
-                  <div className="h-2.5 rounded-full bg-gray-800 overflow-hidden">
+                  <div className="h-2.5 rounded-full bg-gray-100 overflow-hidden">
                     <div
-                      className="h-full rounded-full bg-red-500 transition-all duration-700"
+                      className="h-full rounded-full bg-[#EF7B6C] transition-all duration-700"
                       style={{
                         width: totalMacroGrams > 0
                           ? `${(result.macros.fat / totalMacroGrams) * 100}%`
@@ -441,18 +428,18 @@ export default function NutritionAssistantPage() {
 
             {/* Recommendation */}
             <div
-              className={`rounded-xl border p-4 ${
+              className={`rounded-lg border p-4 ${
                 result.shouldEat
-                  ? "bg-green-500/5 border-green-500/30"
-                  : "bg-red-500/5 border-red-500/30"
+                  ? "bg-[#F0FAF0] border-[#C3E6C3]"
+                  : "bg-[#FEF2F2] border-red-200"
               }`}
             >
               <div className="flex items-center gap-2 mb-2">
                 <span
                   className={`inline-flex items-center gap-1.5 text-xs font-bold uppercase tracking-wider px-2.5 py-1 rounded-full ${
                     result.shouldEat
-                      ? "bg-green-500/20 text-green-400"
-                      : "bg-red-500/20 text-red-400"
+                      ? "bg-[#D4EDDA] text-[#155724]"
+                      : "bg-[#F8D7DA] text-[#721C24]"
                   }`}
                 >
                   {result.shouldEat ? (
@@ -472,7 +459,7 @@ export default function NutritionAssistantPage() {
                   )}
                 </span>
               </div>
-              <p className="text-sm text-gray-300 leading-relaxed">
+              <p className="text-sm text-gray-600 leading-relaxed">
                 {result.recommendation}
               </p>
 
@@ -483,8 +470,8 @@ export default function NutritionAssistantPage() {
                 disabled={speaking}
                 className={`mt-3 inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all ${
                   speaking
-                    ? "bg-gray-800 text-gray-500 cursor-not-allowed"
-                    : "bg-gray-800 hover:bg-gray-700 text-gray-300 hover:text-white"
+                    ? "bg-gray-100 text-gray-400 cursor-not-allowed"
+                    : "bg-gray-100 hover:bg-gray-200 text-gray-600 hover:text-[#1C1E21]"
                 }`}
               >
                 {speaking ? (


### PR DESCRIPTION
## Summary
Complete visual overhaul of all 3 demo apps by a 4-person UI/UX design team (lead + 3 designers).

**Problem:** All apps had a generic "AI demo" aesthetic — dark sci-fi backgrounds, neon gradients, glowing orbs, "Powered by" badges.

**Solution:** Each app now has a distinct, polished visual identity:

- **Text-to-Image** → Warm off-white, monochrome professional (think Unsplash/Figma)
- **Memory Stream** → Warm cream, editorial serif typography, terracotta accents (think Medium/Apple Memories)
- **Nutrition Assistant** → Cool off-white, clinical green, structured cards (think Apple Health/MyFitnessPal)

### What was removed from all apps
- Dark sci-fi backgrounds
- Neon gradient text
- Ambient blur orbs
- "Powered by MiniMax" badges
- Backdrop blur effects
- Colored glow shadows
- Emoji icons in buttons

## Test plan
- [x] Build passes
- [ ] Each demo has a visually distinct light theme
- [ ] No dark/neon/AI aesthetic remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)